### PR TITLE
Repalce FlatButton with TextButton due to deprecation of FlatButton in  Flutter 2.0

### DIFF
--- a/example/lib/date_picker_in_page.dart
+++ b/example/lib/date_picker_in_page.dart
@@ -119,7 +119,7 @@ DateTimePickerTheme(
                       style: TextStyle(fontSize: 14.0),
                     ),
                     actions: <Widget>[
-                      new FlatButton(
+                      new TextButton(
                         child: new Text("OK"),
                         onPressed: () {
                           Navigator.of(context).pop();

--- a/lib/src/widget/date_picker_title_widget.dart
+++ b/lib/src/widget/date_picker_title_widget.dart
@@ -63,8 +63,7 @@ class DatePickerTitleWidget extends StatelessWidget {
 
     return Container(
       height: pickerTheme.titleHeight,
-      child: FlatButton(
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.zero),
+      child: TextButton(
         child: cancelWidget,
         onPressed: () => this.onCancel(),
       ),
@@ -95,8 +94,7 @@ class DatePickerTitleWidget extends StatelessWidget {
 
     return Container(
       height: pickerTheme.titleHeight,
-      child: FlatButton(
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.zero),
+      child: TextButton(
         child: confirmWidget,
         onPressed: () => this.onConfirm(),
       ),


### PR DESCRIPTION
I am using Flutter 3.3.10 , the FlatButton reference in ./lib/src/widget/date_picker_title_widget.dart prevented my app from compiling. This PR replaces FlatButton with TextButton .